### PR TITLE
feat: send transfer

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,16 +5,19 @@ import { DefineGetInfoMethod } from './methods/get-info';
 import { DefineSignPsbtMethod } from './methods/sign-psbt';
 import { DefineGetAddressesMethod } from './methods/get-addresses';
 import { DefineSignMessageMethod } from './methods/sign-message';
+import { DefineSendTransferMethod } from './methods/send-transfer';
 
 export * from './rpc';
 export * from './methods/get-info';
 export * from './methods/sign-psbt';
 export * from './methods/get-addresses';
+export * from './methods/send-transfer';
 
 export type BtcKitMethodMap = DefineGetInfoMethod &
   DefineGetAddressesMethod &
   DefineSignPsbtMethod &
-  DefineSignMessageMethod;
+  DefineSignMessageMethod &
+  DefineSendTransferMethod;
 
 export type BtcKitRequests = ValueOf<BtcKitMethodMap>['request'];
 

--- a/packages/types/src/methods/send-transfer.ts
+++ b/packages/types/src/methods/send-transfer.ts
@@ -1,0 +1,16 @@
+import { DefineRpcMethod, RpcRequest, RpcResponse } from '../rpc';
+
+export interface SendTransferResponseParams {
+  address: string;
+  amount: string;
+}
+
+export interface SendTransferResponseBody {
+  txid: string;
+}
+
+export type SendTransferRequest = RpcRequest<'sendTransfer', SendTransferResponseParams>;
+
+export type SendTransferResponse = RpcResponse<SendTransferResponseBody>;
+
+export type DefineSendTransferMethod = DefineRpcMethod<SendTransferRequest, SendTransferResponse>;


### PR DESCRIPTION
This PR begins to add support for signing a transaction to transfer btc.

Questions:
1.  Should the name be more specific to token transfer?
2. The proposed PR in Connect use a `BtcRecipient` so an app could send an array of recipient, is that also preferred here? Ref PR: https://github.com/hirosystems/connect/pull/285